### PR TITLE
- Fixed textures.scf importing when textures > 20. 

### DIFF
--- a/gxtool/converter.cpp
+++ b/gxtool/converter.cpp
@@ -550,7 +550,7 @@ void CConverter::ReallocImgArray()
 	if(ppImages){
 		memset(ppImages,0,(m_nMaxSrcImgAlloc+20)*sizeof(_tsImage*));
 		if(m_ppSrcImages) {
-			memcpy(ppImages,m_ppSrcImages,m_nMaxSrcImgAlloc);
+			memcpy(ppImages,m_ppSrcImages,m_nMaxSrcImgAlloc*sizeof(_tsImage*));
 			delete [] m_ppSrcImages;
 		}
 	}


### PR DESCRIPTION
The code wasn't copying the whole array after reallocation, causing a Segmentation fault