### PR TITLE
elf2d should return success when -h option

### DIFF
--- a/elftool/elf2dol.c
+++ b/elftool/elf2dol.c
@@ -435,7 +435,7 @@ int main(int argc, char **argv)
 	while(argc && *arg[0] == '-') {
 		if(!strcmp(*arg, "-h")) {
 			usage(argv[0]);
-			return 1;
+			return 0;
 		} else if(!strcmp(*arg, "-v")) {
 			verbosity++;
 		} else if(!strcmp(*arg, "--")) {


### PR DESCRIPTION
When calling `elf2dol -h` I expect a success and not a failure. 